### PR TITLE
[Fix]: Validate callback function check passed parameter to be a number instead of a string

### DIFF
--- a/includes/class-pzz-api-client.php
+++ b/includes/class-pzz-api-client.php
@@ -267,7 +267,8 @@ class Pzz_Api_Client
                 return (array(
                     'Authorization' => array(
                         'validate_callback' => function ($param, $request, $key) {
-                            return is_numeric($param);
+                            return is_string($param);
+
                         },
                         'description' => 'JWT Bearer token should be placed in the request header.',
                         'type' => 'string'


### PR DESCRIPTION
This gets Authorization token as a parameter in the header that is a string but the validate callback function checks it to be a numerical value instead of a string.